### PR TITLE
yoast/phpunit-polyfills を require-dev へ移動

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -19,17 +19,16 @@
             "phpcs --config-set installed_paths $(pwd)/vendor/wp-coding-standards/wpcs",
             "phpcbf --standard=phpcs.ruleset.xml ./src"
         ]
-
     },
     "minimum-stability": "stable",
     "require": {
         "php": ">=5.6",
         "kunoichi/bootstrapress": "^1.0.2",
-        "hametuha/singleton-pattern": "^1.2",
-        "yoast/phpunit-polyfills": "^1.0"
+        "hametuha/singleton-pattern": "^1.2"
     },
     "require-dev": {
         "phpunit/phpunit": ">=5.7",
+        "yoast/phpunit-polyfills": "^1.0",
         "squizlabs/php_codesniffer": "^3.0",
         "wp-coding-standards/wpcs": "^2.0"
     },


### PR DESCRIPTION
## 概要

テスト専用パッケージである \`yoast/phpunit-polyfills\` を \`require\`（本番依存）から \`require-dev\`（開発依存）へ移動しました。

## 背景

\`kunoichi/icon\` を依存に持つプロジェクトで \`composer install --no-dev\` を実行しても、\`yoast/phpunit-polyfills\` が本番依存扱いになるため、その先の \`phpunit/phpunit\` まで芋づる式にインストールされていました。

## 変更内容

- \`composer.json\`: \`yoast/phpunit-polyfills\` を \`require\` → \`require-dev\` へ移動

## 検証

\`composer install --no-dev --dry-run\` で polyfills（およびphpunit）が除外されることを確認:

\`\`\`
- Removing yoast/phpunit-polyfills (1.0.4)
\`\`\`

なお \`composer.lock\` は本リポジトリでは \`.gitignore\` 対象であり、ライブラリの lock は下流の利用側では参照されないため、修正は \`composer.json\` のみで完結します。

Fixes #9

🤖 Generated with [Claude Code](https://claude.com/claude-code)