### PR TITLE
chore: composer まわりの近代化と配布アーカイブの最小化

### DIFF
--- a/.gitattributes
+++ b/.gitattributes
@@ -1,0 +1,23 @@
+# Files excluded from the Composer/GitHub distribution archive (`git archive`).
+# Keep runtime files only: src/, dist/, languages/, icon.php, composer.json, LICENSE, README.md.
+# `assets/` holds the un-built SCSS/JS sources, so it is dev-only (built output lives in dist/).
+
+/.distignore       export-ignore
+/.eslintrc         export-ignore
+/.stylelintrc.json export-ignore
+/.gitignore        export-ignore
+/.gitattributes    export-ignore
+/.github           export-ignore
+/.idea             export-ignore
+/.wp-env.json      export-ignore
+/assets            export-ignore
+/bin               export-ignore
+/tests             export-ignore
+/wordpress         export-ignore
+/gulpfile.js       export-ignore
+/webpack.config.js export-ignore
+/package.json      export-ignore
+/package-lock.json export-ignore
+/composer.lock     export-ignore
+/phpcs.ruleset.xml export-ignore
+/phpunit.xml.dist  export-ignore

--- a/composer.json
+++ b/composer.json
@@ -21,8 +21,13 @@
         ]
     },
     "minimum-stability": "stable",
+    "config": {
+        "platform": {
+            "php": "7.4"
+        }
+    },
     "require": {
-        "php": ">=5.6",
+        "php": ">=7.4",
         "kunoichi/bootstrapress": "^1.0.2",
         "hametuha/singleton-pattern": "^1.2"
     },


### PR DESCRIPTION
## 概要

ツールチェイン（composer 周り）の chore。コードの挙動には影響しない設定・配布まわりの整備です。

## 変更内容

### 1. PHP 要件を実態に合わせる
- `require.php` を `>=5.6` → `>=7.4` に。CI matrix は既に `7.4`/`8.0` のみ。
- `config.platform.php = 7.4` を追加。依存解決を最小サポート版に固定し、開発機の PHP バージョン差で解決結果がブレないようにする。

### 2. `.gitattributes` で配布アーカイブを最小化
- `export-ignore` を追加し、Packagist/`git archive` の配布物から dev ファイル（`assets`(SCSSソース), `bin`, `tests`, `*.config.js`, lint 設定, `package*.json`, `composer.lock` 等）を除外。
- **ランタイム資産は保持**: `src/`, `dist/`（ビルド済みJS/CSS/webfonts、`Manager.php` が enqueue）, `languages/`, `icon.php`, `composer.json`, `LICENSE`, `README.md`。
- 既存の `.distignore`（`wp dist-archive` 用）は GitHub Release zip 向けにそのまま残置。

### `composer.lock` は引き続きコミットしない
- ライブラリでの lock コミットは「CI が固定依存しかテストしなくなる」非推奨パターンのため、`.gitignore` 管理下のまま維持。

## 検証

\`\`\`
$ composer validate            # ./composer.json is valid
$ composer install --no-dev    # phpunit / polyfills / phpcs / wpcs すべて除外を確認
$ git archive HEAD | tar -t    # composer.json dist icon.php languages LICENSE README.md src のみ
\`\`\`

## 対象外（別途）

- npm 依存の近代化（webpack4/gulp-sass(node-sass)/eslint6 等）は**破壊的移行**のため本PRから除外。→ #12

🤖 Generated with [Claude Code](https://claude.com/claude-code)