### PR TITLE
未使用の kunoichi/bootstrapress 依存を削除

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -28,7 +28,6 @@
     },
     "require": {
         "php": ">=7.4",
-        "kunoichi/bootstrapress": "^1.0.2",
         "hametuha/singleton-pattern": "^1.2"
     },
     "require-dev": {


### PR DESCRIPTION
## 概要

`composer.json` の require から `kunoichi/bootstrapress` を削除します。

## 理由

- リポジトリ全体を調査したところ、`Kunoichi\BootstraPress\*` のクラスは `use` / `extends` / 呼び出しのいずれも**一切行われていません**。参照は `composer.json` の require 行のみでした。
- アイコンフォントの CSS パースは `Kunoichi\Icon\Pattern\IconSet` の各サブクラス（例: `Dashicons::get_icon_list()`）で独自の正規表現により自前実装されており、bootstrapress の `Css\Extractor` には依存していません。
- `kuno1/bootstrapress` は現在アーカイブ済みであり、未使用の依存を残す利点がありません。

## 影響

- コード上の利用箇所がないため、動作への影響はありません。
- `composer.lock` は未コミット（ライブラリのため）なので追従不要です。

🤖 Generated with [Claude Code](https://claude.com/claude-code)