### PR TITLE
Widen yoast/phpunit-polyfills constraint (#19)

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -29,7 +29,7 @@
     },
     "require-dev": {
         "phpunit/phpunit": ">=5.7",
-        "yoast/phpunit-polyfills": "^1.0",
+        "yoast/phpunit-polyfills": "^1.1.1 || ^2.0 || ^3.0",
         "squizlabs/php_codesniffer": "^3.9",
         "wp-coding-standards/wpcs": "^3.0"
     },


### PR DESCRIPTION
## 背景

Issue #19 の本題（\`yoast/phpunit-polyfills\` を \`require\` → \`require-dev\` へ移動）は、すでにリリース済みの **1.0.5** で解決済みです（Packagist でも確認）。`require-dev` の制約は依存先プロジェクトには伝播しないため、kunoichi-market(hakama) 側は \`kunoichi/icon: ^1.0.5\` に上げれば衝突は解消します。

> ⚠️ Issue に記載の \`fix/move-phpunit-polyfills-to-dev\` ブランチは #16 のモダナイズより前の古いブランチで、マージすると php\`>=5.6\`・wpcs\`^2.0\`・\`kunoichi/bootstrapress\` などへ巻き戻ってしまうため使用しません。

## このPRの変更

残課題だった `^1.0` の上限を緩和します。

```diff
- "yoast/phpunit-polyfills": "^1.0",
+ "yoast/phpunit-polyfills": "^1.1.1 || ^2.0 || ^3.0",
```

- これは `require-dev` のみの変更で、依存先には影響しません（icon自身のCI/開発環境が polyfills 2.x/3.x を使えるようにするための衛生改善）。
- WordPress core / WPCS が採用している範囲に揃えています（WP 6.9 のテストスイートは `>= 1.1.0` を要求）。
- ローカルで `composer update` 済み: polyfills `1.1.5 → 3.1.2` に解決、`phpunit/phpunit 9.6.34` は据え置き、`composer validate` パス。
- 挙動検証はCIの PHPUnit ジョブ（wp-env）に委ねています。

Closes #19

🤖 Generated with [Claude Code](https://claude.com/claude-code)